### PR TITLE
PHP function eregi() was removed in PHP 7.0.0.

### DIFF
--- a/includes/options.php
+++ b/includes/options.php
@@ -66,8 +66,8 @@
 	$fileCount=0;
 	$dir = opendir($filePath);
 	while ($file = readdir($dir)) {
-	 
-	  if (eregi("\.css",$file)) { /* Look for files with .png extension */
+
+	  if (preg_match("/\.css/i",$file)) { /* Look for files with .png extension */
 		$flie_name=explode('.',$file);
 		echo '<option value="'.$flie_name[0].'"'; ?>
 		<?php selected($flie_name[0], $options['template']); ?>>


### PR DESCRIPTION
Use `preg_match()` to replace php 7.0.0 deprecated function `eregi()`